### PR TITLE
EPUB_Frame

### DIFF
--- a/sdk/src/asset_handlers/epub_io.rs
+++ b/sdk/src/asset_handlers/epub_io.rs
@@ -1,0 +1,103 @@
+use crate::{
+    asset_io::{AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, HashObjectPositions},
+    // assertions::Metadata,
+    error::Result,
+};
+
+use std::path::Path;
+
+static SUPPORTED_TYPES: [&str; 6] = [
+    "epub",
+    "application/epub+zip",
+    "application/zip",
+    "application/octet-stream",
+    "zip",
+    ""
+];
+pub struct EpubIo;
+
+impl AssetIO for EpubIo {
+    fn supported_types(&self) -> &[&str] {
+        println!("supported_types called for EPUB");
+        &SUPPORTED_TYPES
+    }
+
+    fn new(_asset_type: &str) -> Self {
+        println!("EpubIo::new() called");
+
+        EpubIo
+    }
+
+    fn get_handler(&self, _asset_type: &str) -> Box<dyn AssetIO> {
+        Box::new(EpubIo::new(""))
+    }
+
+    fn get_reader(&self) -> &dyn CAIReader {
+        self
+    }
+
+    fn get_writer(&self, _asset_type: &str) -> Option<Box<dyn CAIWriter>> {
+        Some(Box::new(EpubIo))
+    }
+
+    fn read_cai_store(&self, asset_path: &Path) -> Result<Vec<u8>> {
+        println!("EPUB read_cai_store called on {:?}", asset_path);
+        Ok(vec![]) //temporarily return empty vec
+    }
+
+    fn save_cai_store(&self, asset_path: &Path, _store_bytes: &[u8]) -> Result<()> {
+        println!("EPUB save_cai_store called on {:?}", asset_path);
+        Ok(())
+    }
+
+    fn get_object_locations(&self, asset_path: &Path) -> Result<Vec<HashObjectPositions>> {
+        println!("EPUB get_object_locations called on {:?}", asset_path);
+        Ok(vec![]) // stub implementation
+    }
+
+    fn remove_cai_store(&self, asset_path: &Path) -> Result<()> {
+        println!("EPUB remove_cai_store called on {:?}", asset_path);
+        Ok(())
+    }
+}
+
+impl CAIReader for EpubIo {
+    fn read_cai(&self, _reader: &mut dyn CAIRead) -> Result<Vec<u8>> {
+        println!("EPUB read_cai called!");
+        Ok(vec![])
+    }
+
+    fn read_xmp(&self, _reader: &mut dyn CAIRead) -> Option<String> {
+        println!("EPUB read_xmp called!");
+        None
+    }
+}
+
+impl CAIWriter for EpubIo {
+    fn write_cai(
+        &self,
+        _input: &mut dyn CAIRead,
+        _output: &mut dyn CAIReadWrite,
+        _store_bytes: &[u8],
+    ) -> Result<()> {
+        println!("EPUB write_cai called!");
+        Ok(())
+    }
+
+    fn get_object_locations_from_stream(
+        &self,
+        _input_stream: &mut dyn CAIRead,
+    ) -> Result<Vec<HashObjectPositions>> {
+        println!("EPUB get_object_locations_from_stream called!");
+        Ok(vec![])
+    }
+
+    fn remove_cai_store_from_stream(
+        &self,
+        _input_stream: &mut dyn CAIRead,
+        _output_stream: &mut dyn CAIReadWrite,
+    ) -> Result<()> {
+        println!("EPUB remove_cai_store_from_stream called!");
+        Ok(())
+    }
+}

--- a/sdk/src/asset_handlers/mod.rs
+++ b/sdk/src/asset_handlers/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod bmff_io;
 pub mod c2pa_io;
+pub mod epub_io;
 pub mod gif_io;
 pub mod jpeg_io;
 pub mod mp3_io;

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -28,7 +28,7 @@ use crate::asset_handlers::pdf_io::PdfIO;
 use crate::{
     asset_handlers::{
         bmff_io::BmffIO, c2pa_io::C2paIO, gif_io::GifIO, jpeg_io::JpegIO, mp3_io::Mp3IO,
-        png_io::PngIO, riff_io::RiffIO, svg_io::SvgIO, tiff_io::TiffIO,
+        png_io::PngIO, riff_io::RiffIO, svg_io::SvgIO, tiff_io::TiffIO, epub_io::EpubIo,
     },
     asset_io::{AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, HashObjectPositions},
     error::{Error, Result},
@@ -49,6 +49,7 @@ lazy_static! {
             Box::new(TiffIO::new("")),
             Box::new(Mp3IO::new("")),
             Box::new(GifIO::new("")),
+            Box::new(EpubIo::new("")),
         ];
 
         let mut handler_map = HashMap::new();
@@ -78,6 +79,7 @@ lazy_static! {
             Box::new(TiffIO::new("")),
             Box::new(Mp3IO::new("")),
             Box::new(GifIO::new("")),
+            Box::new(EpubIo::new("")),
         ];
         let mut handler_map = HashMap::new();
 

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -42,6 +42,7 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
         "arw" => "image/x-sony-arw",
         "nef" => "image/x-nikon-nef",
         "c2pa" | "application/x-c2pa-manifest-store" | "application/c2pa" => "application/c2pa",
+        "epub" => "application/epub+zip",
         _ => return None,
     })
 }


### PR DESCRIPTION
1. Registeration of EPUB 

• added a mapping for the EPUB MIME type (application/epub+zip) in the 
mime utility (sdk/src/utils/mime.rs) so that the tool can recognize the “.epub” 
extension 
• registered our EPUB handler (EpubIo) in the global asset handler table (in 
sdk/src/jumbf_io.rs) 
• added “use crate::asset_handlers::epub_io::EpubIo;” at the top. 
With that registration, the c2patool now recognizes EPUB files (means no 
longer returns “Unsupported file type” when you run “c2patool sample.epub.”